### PR TITLE
Support vdp_video_surface_put_bits_y_cb_cr.

### DIFF
--- a/h264.c
+++ b/h264.c
@@ -573,6 +573,7 @@ int h264_decode(decoder_ctx_t *decoder, VdpPictureInfoH264 const *info, const in
 	c->picture_height_in_mbs_minus1 = (decoder->height - 1) / 16;
 	c->info = info;
 	c->output = output;
+	output->source_format = INTERNAL_YCBCR_FORMAT;
 
 	if (!c->info->frame_mbs_only_flag)
 	{

--- a/mpeg12.c
+++ b/mpeg12.c
@@ -54,6 +54,7 @@ int mpeg12_decode(decoder_ctx_t *decoder, VdpPictureInfoMPEG1Or2 const *info, co
 
 	int i;
 	void *ve_regs = ve_get_regs();
+	output->source_format = INTERNAL_YCBCR_FORMAT;
 
 	// activate MPEG engine
 	writel((readl(ve_regs + VE_CTRL) & ~0xf) | 0x0, ve_regs + VE_CTRL);

--- a/presentation_queue.c
+++ b/presentation_queue.c
@@ -231,12 +231,34 @@ VdpStatus vdp_presentation_queue_display(VdpPresentationQueue presentation_queue
 	memset(&layer_info, 0, sizeof(layer_info));
 	layer_info.pipe = 1;
 	layer_info.mode = DISP_LAYER_WORK_MODE_SCALER;
-	layer_info.fb.mode = DISP_MOD_MB_UV_COMBINED;
 	layer_info.fb.format = DISP_FORMAT_YUV420;
 	layer_info.fb.seq = DISP_SEQ_UVUV;
+	switch (os->vs->source_format) {
+	case VDP_YCBCR_FORMAT_YUYV:
+		layer_info.fb.mode = DISP_MOD_INTERLEAVED;
+		layer_info.fb.format = DISP_FORMAT_YUV422;
+		layer_info.fb.seq = DISP_SEQ_YUYV;
+		break;
+	case VDP_YCBCR_FORMAT_UYVY:
+		layer_info.fb.mode = DISP_MOD_INTERLEAVED;
+		layer_info.fb.format = DISP_FORMAT_YUV422;
+		layer_info.fb.seq = DISP_SEQ_UYVY;
+		break;
+	case VDP_YCBCR_FORMAT_NV12:
+		layer_info.fb.mode = DISP_MOD_NON_MB_UV_COMBINED;
+		break;
+	case VDP_YCBCR_FORMAT_YV12:
+		layer_info.fb.mode = DISP_MOD_NON_MB_PLANAR;
+		break;
+	default:
+	case INTERNAL_YCBCR_FORMAT:
+		layer_info.fb.mode = DISP_MOD_MB_UV_COMBINED;
+		break;
+	}
 	layer_info.fb.br_swap = 0;
 	layer_info.fb.addr[0] = ve_virt2phys(os->vs->data) + 0x40000000;
 	layer_info.fb.addr[1] = ve_virt2phys(os->vs->data + os->vs->plane_size) + 0x40000000;
+	layer_info.fb.addr[2] = ve_virt2phys(os->vs->data + os->vs->plane_size + os->vs->plane_size / 4) + 0x40000000;
 
 	layer_info.fb.cs_mode = DISP_BT601;
 	layer_info.fb.size.width = os->vs->width;

--- a/vdpau_private.h
+++ b/vdpau_private.h
@@ -28,6 +28,8 @@
 #include <vdpau/vdpau.h>
 #include <X11/Xlib.h>
 
+#define INTERNAL_YCBCR_FORMAT (VdpYCbCrFormat)0xffff
+
 typedef struct
 {
 	Display *display;


### PR DESCRIPTION
Tested in MPlayer to work with uncompressed YV12, NV12, YUYV and UYUV.
Allows using VDPAU also for videos that have no hardware decoder support.
