### PR TITLE
Add hackish support for brightness, contrast and saturation.

### DIFF
--- a/presentation_queue.c
+++ b/presentation_queue.c
@@ -287,6 +287,25 @@ VdpStatus vdp_presentation_queue_display(VdpPresentationQueue presentation_queue
 
 	ioctl(q->target->fd, DISP_CMD_LAYER_BOTTOM, args);
 	ioctl(q->target->fd, DISP_CMD_LAYER_OPEN, args);
+	// Note: might be more reliable (but slower and problematic when there
+	// are driver issues and the GET functions return wrong values) to query the
+	// old values instead of relying on our internal csc_change.
+	// Since the driver calculates a matrix out of these values after each
+	// set doing this unconditionally is costly.
+	if (os->csc_change) {
+		ioctl(q->target->fd, DISP_CMD_LAYER_ENHANCE_OFF, args);
+		args[2] = 0xff * os->brightness + 0x20;
+		ioctl(q->target->fd, DISP_CMD_LAYER_SET_BRIGHT, args);
+		args[2] = 0x20 * os->contrast;
+		ioctl(q->target->fd, DISP_CMD_LAYER_SET_CONTRAST, args);
+		args[2] = 0x20 * os->saturation;
+		ioctl(q->target->fd, DISP_CMD_LAYER_SET_SATURATION, args);
+		// hue scale is randomly chosen, no idea how it maps exactly
+		args[2] = (32 / 3.14) * os->hue + 0x20;
+		ioctl(q->target->fd, DISP_CMD_LAYER_SET_HUE, args);
+		ioctl(q->target->fd, DISP_CMD_LAYER_ENHANCE_ON, args);
+		os->csc_change = 0;
+	}
 
 	return VDP_STATUS_OK;
 }

--- a/surface_output.c
+++ b/surface_output.c
@@ -38,6 +38,8 @@ VdpStatus vdp_output_surface_create(VdpDevice device, VdpRGBAFormat rgba_format,
 	out->width = width;
 	out->height = height;
 	out->rgba_format = rgba_format;
+	out->contrast = 1.0;
+	out->saturation = 1.0;
 	out->device = dev;
 
 	int handle = handle_create(out);

--- a/vdpau_private.h
+++ b/vdpau_private.h
@@ -78,6 +78,11 @@ typedef struct
 typedef struct
 {
 	device_ctx_t *device;
+	int csc_change;
+	float brightness;
+	float contrast;
+	float saturation;
+	float hue;
 } mixer_ctx_t;
 
 typedef struct
@@ -87,6 +92,11 @@ typedef struct
 	uint32_t width, height;
 	video_surface_ctx_t *vs;
 	VdpRect video_src_rect, video_dst_rect;
+	int csc_change;
+	float brightness;
+	float contrast;
+	float saturation;
+	float hue;
 } output_surface_ctx_t;
 
 #ifndef ARRAY_SIZE


### PR DESCRIPTION
Support for hue is there in principle, but would need tweaking,
Due to the very limited range supported by the driver I didn't
manage to do that.
The hardware actually has full support for arbitrary CSC matrices,
but since it is not exposed some hack like this is the best I could
think of.
Patch also fixes vdp_generate_csc_matrix to write the data to
the correct location, previously it would actually write outside
the matrix.

---

Note: I am not really happy with it, but it's the best I can think of so far and I think it might be useful to others as-is already
