### PR TITLE
Avoid stropts.h to fix compilation.

### DIFF
--- a/surface_bitmap.c
+++ b/surface_bitmap.c
@@ -18,7 +18,7 @@
  */
 
 #include <string.h>
-#include <stropts.h>
+#include <sys/ioctl.h>
 #include "vdpau_private.h"
 #include "ve.h"
 #include "g2d_driver.h"

--- a/surface_output.c
+++ b/surface_output.c
@@ -17,7 +17,7 @@
  *
  */
 
-#include <stropts.h>
+#include <sys/ioctl.h>
 #include "vdpau_private.h"
 #include "ve.h"
 #include "g2d_driver.h"

--- a/video_mixer.c
+++ b/video_mixer.c
@@ -18,7 +18,7 @@
  */
 
 #include <math.h>
-#include <stropts.h>
+#include <sys/ioctl.h>
 #include "vdpau_private.h"
 #include "ve.h"
 #include "g2d_driver.h"


### PR DESCRIPTION
There is no stropts.h on my system.
Also the documentation says to include sys/ioctl.h
for ioctl().
The files do not seem to use the streams interface
(e.g. strioctl struct) that stropts.h is intended
to be used for.

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
