### PR TITLE
Add rescaled screen detection and screen1 (/dev/fb1) support

### DIFF
--- a/README
+++ b/README
@@ -27,3 +27,7 @@ This partly breaks X11 integration due to hardware limitations. The video
 area can't be overlapped by other windows. For fullscreen use this is no
 problem.
 Note: this needs G2D, so make sure that you have write access to /dev/g2d.
+
+You can play video on second screen (when using separate framebuffer on /dev/fb1) with VDPAU_SCREEN
+enviroment variable.
+    $ export VDPAU_SCREEN=1

--- a/device.c
+++ b/device.c
@@ -54,6 +54,14 @@ VdpStatus vdp_imp_device_create_x11(Display *display,
 			VDPAU_DBG("Failed to open /dev/g2d! OSD disabled.");
 	}
 
+	char *env_vdpau_screen=getenv("VDPAU_SCREEN");
+	if(env_vdpau_screen)
+	{
+		dev->screen_i=atoi(env_vdpau_screen);
+	}
+	else
+		dev->screen_i=0;
+
 	int handle = handle_create(dev);
 	if (handle == -1)
 	{

--- a/vdpau_private.h
+++ b/vdpau_private.h
@@ -39,6 +39,7 @@ typedef struct
 	int fd;
 	int g2d_fd;
 	int osd_enabled;
+	int screen_i;
 } device_ctx_t;
 
 typedef struct video_surface_ctx_struct
@@ -70,6 +71,11 @@ typedef struct
 	int fd;
 	int layer;
 	int layer_top;
+	int sc_src_width;
+	int sc_src_height;
+	int sc_width;
+	int sc_height;
+	int screen_i;
 } queue_target_ctx_t;
 
 typedef struct


### PR DESCRIPTION
Now vdpau driver does not work with separate screen configuration. This enables it using VDPAU_SCREEN env variable to set screen number.
Vdpau also does not support rescaled screens (using hardware scaler layer ). I added code, thet detects scaling and corrects layer rect.
