### PR TITLE
Fix null pointer dereference accessing reference pics in h264_decode() function

### DIFF
--- a/h264.c
+++ b/h264.c
@@ -694,7 +694,7 @@ static VdpStatus h264_decode(decoder_ctx_t *decoder,
 				int j;
 				uint32_t list = 0;
 				for (j = 0; j < 4; j++)
-					if (h->RefPicList0[i + j])
+					if (h->RefPicList0[i + j] && h->RefPicList0[i + j]->surface)
 					{
 						h264_video_private_t *surface_p = (h264_video_private_t *)h->RefPicList0[i + j]->surface->decoder_private;
 						list |= ((surface_p->pos * 2) << (j * 8));


### PR DESCRIPTION
It fixes crashes when changing aspect ratio of h264 files in mplayer.

How to reproduce it

```
Open an h264 video file using mplayer slave mode:
mplayer -osdlevel 0 -msglevel all=-1:global=4:identify=5 -fs -slave -input nodefault-bindings -noconfig all -vo vdpau -vc ffmpeg12vdpau,ffh264vdpau,ffodivxvdpau,-ffwmv3vdpau,-ffvc1vdpau, /tmp/usb/medios/ElephantsDream-DivXPlusHD.mkv

Change the aspect ratio:
switch_ratio 1.333333
```

With this change, i see artifacts in the video for a couple of seconds because of the lost of reference frames. I don't know if there is a better fix, i don't know all the code yet. If you have any hint i can try a better fix but i think this is better than a crash.