### PR TITLE
Add rescaled screen detection and screen1 (/dev/fb1) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,20 @@ $ export VDPAU_DISABLE_G2D=1
 
 If using G2D (A10/A20), make sure to have write access to `/dev/g2d`.
 
+# Play video on second screen
+
+Because X video driver is baypassed and own disp layers are directly used, physical screen number must be specified using VDPAU_SCREEN env var. If VDPAU_SCREEN is not specified, the same screen number than the one used by the X server will be used.
+
+This is enough for the most common Xorg configurations:
+
+* 1 screen: Xorg screen 0 is physical screen 0
+* 2 screens: Xorg screen 0 is physical screen 0 and Xorg screen 1 is physical screen 1.
+
+If your Xorg configuration is different, you must set VDPAU_SCREEN env var to 0 or 1 (even if using extended desktop configurations, see limitations below).
+
 # Limitations:
 
 * Output bypasses X video driver by opening own disp layers. You can't use Xv from fbturbo at the same time, and on H3 the video is always on top and can't be overlapped by other windows.
 * OSD partly breaks X11 integration due to hardware limitations. The video area can't be overlapped by other windows. For fullscreen use this is no problem.
 * There is no [OpenGL interoperation feature] (https://www.opengl.org/registry/specs/NV/vdpau_interop.txt) because we are on ARM and only have OpenGL/ES available.
+* VDPAU_SCREEN must be specified if Xorg screen numbers doesn't match physical screen numbers. Also if video is played in second monitor when using a extended desktop configuration (such as Xinerama). In this case, video can't be played partially in one monitor and partially in the other.

--- a/device.c
+++ b/device.c
@@ -51,6 +51,17 @@ VdpStatus vdp_imp_device_create_x11(Display *display,
 
 	char *env_vdpau_osd = getenv("VDPAU_OSD");
 	char *env_vdpau_g2d = getenv("VDPAU_DISABLE_G2D");
+	char *env_vdpau_screen = getenv("VDPAU_SCREEN");
+	
+	if (env_vdpau_screen) {
+		dev->screen_i = atoi(env_vdpau_screen);
+		VDPAU_DBG("VDPAU_SCREEN set to %d", dev->screen_i);
+	}
+	else {
+		dev->screen_i = screen; // try same than X screen
+		VDPAU_DBG("VDPAU_SCREEN not set, trying screen %d", dev->screen_i);
+	}
+
 	if (env_vdpau_osd && strncmp(env_vdpau_osd, "1", 1) == 0)
 		dev->osd_enabled = 1;
 	else
@@ -71,7 +82,7 @@ VdpStatus vdp_imp_device_create_x11(Display *display,
 
 	if (!dev->g2d_enabled)
 		VDPAU_DBG("OSD enabled, using pixman");
-
+	
 	return VDP_STATUS_OK;
 }
 

--- a/presentation_queue.c
+++ b/presentation_queue.c
@@ -55,7 +55,7 @@ VdpStatus vdp_presentation_queue_target_create_x11(VdpDevice device,
 	qt->drawable = drawable;
 	XSetWindowBackground(dev->display, drawable, 0x000102);
 
-	qt->disp = sunxi_disp_open(dev->osd_enabled);
+	qt->disp = sunxi_disp_open(dev->screen_i, dev->osd_enabled);
 
 	if (!qt->disp)
 		qt->disp = sunxi_disp2_open(dev->osd_enabled);

--- a/sunxi_disp.h
+++ b/sunxi_disp.h
@@ -31,7 +31,7 @@ struct sunxi_disp
 	void (*close_osd_layer)(struct sunxi_disp *sunxi_disp);
 };
 
-struct sunxi_disp *sunxi_disp_open(int osd_enabled);
+struct sunxi_disp *sunxi_disp_open(int screen_i, int osd_enabled);
 struct sunxi_disp *sunxi_disp2_open(int osd_enabled);
 struct sunxi_disp *sunxi_disp1_5_open(int osd_enabled);
 

--- a/vdpau_private.h
+++ b/vdpau_private.h
@@ -38,13 +38,14 @@ typedef struct
 {
 	cedrus_t *cedrus;
 	Display *display;
-	int screen;
+	int screen; // X screen
 	VdpPreemptionCallback *preemption_callback;
 	void *preemption_callback_context;
 	int fd;
 	int g2d_fd;
 	int osd_enabled;
 	int g2d_enabled;
+	int screen_i; // sunxi disp screen
 } device_ctx_t;
 
 typedef struct


### PR DESCRIPTION
Screen is selected with VDPAU_SCREEN env var, or used the same than
X screen (normally Xorg will be configured to :0.0 to be disp screen
0 and :0.1 to be disp screen 1. If not VDPAU_SCREEN env var is
required).

This change is based in this commit authored by mittorn:
https://github.com/mittorn/libvdpau-sunxi/commit/319bd475f30196480ff83afb0dbe841e7978c672